### PR TITLE
[update] Log表示追加・マップデータの運び屋

### DIFF
--- a/プロトタイプ/GameMgr.cpp
+++ b/プロトタイプ/GameMgr.cpp
@@ -8,6 +8,8 @@ void cGameMgr::Init() {
 	cTime* ptime = new cTime(TIME_LIMIT);
 	m_time = *ptime;
 	m_img = LoadGraph("../resource/img/GameBG.png");
+
+	m_PUnit.Set_MapData(m_mapMgr.GetRoomSize());
 }
 
 void cGameMgr::Update() {
@@ -22,6 +24,8 @@ void cGameMgr::Update() {
   
   PUnitGenerate();
 	EUnitGenerate();
+
+	cLog::Instance()->Update();
 
 #ifdef GAMEMGR_DEBUG
 	if (GET_KEY_PRESS(KEY_INPUT_E) == 1) {
@@ -60,6 +64,8 @@ void cGameMgr::Draw() {
 	m_time.Draw();
     m_EUnit.Draw();
 
+	cLog::Instance()->Draw();
+
 #ifdef GAMEMGR_DEBUG
 	DrawFormatString(0, 0, WH, "ゲーム画面");
 	//DrawBox(100,100,600,600,GR,TRUE);
@@ -93,9 +99,9 @@ void cGameMgr::PUnitGenerate() {
 		int tmp = m_mapMgr.CheckInto(MOUSE_V.x, MOUSE_V.y);
 		if (tmp != -1)
 		{
-			//m_PUnit.Add_PSord(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2, tmp);
-			m_PUnit.Add_PSord(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2);
-			DEBUG_LOG("剣出現");
+			m_PUnit.Add_PSord(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2, tmp);
+			//m_PUnit.Add_PSord(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2);
+			//DEBUG_LOG("剣出現");
 		}
 	}
 	else if (MOUSE_PRESS(LEFT_CLICK) == 1 && CheckHitKey(KEY_INPUT_A) >= 1)
@@ -103,8 +109,8 @@ void cGameMgr::PUnitGenerate() {
 		int tmp = m_mapMgr.CheckInto(MOUSE_V.x, MOUSE_V.y);
 		if (tmp != -1)
 		{
-			//m_PUnit.Add_PArcher(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2, tmp);
-			m_PUnit.Add_PArcher(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2);
+			m_PUnit.Add_PArcher(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2, tmp);
+			//m_PUnit.Add_PArcher(MOUSE_V.x, m_mapMgr.Get_Ground(tmp) + UNIT_HEIGHT / 2);
 		}
 	}
 	else if (MOUSE_PRESS(LEFT_CLICK) == 1 && cMouse::Instance()->GetPlayerNum() >= 0 && CheckHitKeyAll != 0)

--- a/プロトタイプ/GameMgr.h
+++ b/プロトタイプ/GameMgr.h
@@ -16,6 +16,7 @@
 #include "EscortTarget.h"
 #include "TimeLimit.h"
 //#include "Result.h"
+#include "Log.h"
 
 #ifndef _INCLUDE_GAMEMGR_
 #define _INCLUDE_GAMEMGR_


### PR DESCRIPTION
Logの表示をここからするようにした
初期化の段階でマップのデータをUnitに渡す仲介処理
ついでに細かな修正

﻿↑↑実装の概要(必ず記入)↑↑
●フリー記入覧
　
 ※下記の物はあれば記入すること
●レビューして欲しいところ
●ここはこうしたけどこの点で問題はないだろうか
●不安に思っていること
●保留してること
●スケジュール(マージすべき日、リリースすべき日の指定があれば)
●関係するプルリクエスト