### PR TITLE
[update] ランダム出現のエネミーが全部ESordだったのを改善

### DIFF
--- a/src/GameMgr.cpp
+++ b/src/GameMgr.cpp
@@ -280,16 +280,15 @@ void cGameMgr::EnemyGenerate() {
 
 	if (m_spawnCnt == SPAWN_CNT) {
 		switch (m_spawnType) {
-		case 0:	m_unitMgr.Add_ESord(m_mapMgr.GetStartRoomNum(), m_mapMgr.Get_Ground(5) + UNIT_HEIGHT / 2);
+		case 0:	m_unitMgr.Add_ESord(m_mapMgr.GetStartRoomNum(), m_mapMgr.Get_Ground(0) + UNIT_HEIGHT / 2);
 			m_spawnCnt = 0;
 			break;
-		case 1:	m_unitMgr.Add_EArcher(m_mapMgr.GetStartRoomNum(), m_mapMgr.Get_Ground(5) + UNIT_HEIGHT / 2);
+		case 1:	m_unitMgr.Add_EArcher(m_mapMgr.GetStartRoomNum(), m_mapMgr.Get_Ground(0) + UNIT_HEIGHT / 2);
 			m_spawnCnt = 0;
 			break;
-		case 2:	m_unitMgr.Add_EDefense(m_mapMgr.GetStartRoomNum(), m_mapMgr.Get_Ground(5) + UNIT_HEIGHT / 2);
+		case 2:	m_unitMgr.Add_EDefense(m_mapMgr.GetStartRoomNum(), m_mapMgr.Get_Ground(0) + UNIT_HEIGHT / 2);
 			m_spawnCnt = 0;
 			break;
-			// TODO :なぜかマップnumber2にリスポーンする
 		}
 	}
 }

--- a/src/UnitMgr.h
+++ b/src/UnitMgr.h
@@ -31,8 +31,8 @@ using namespace std;
 #ifndef _INCLUED_UNIT_MGR_
 #define _INCLUED_UNIT_MGR_
 
-#define MOVE_COOLTIME_MAX 500    //  Randで0~500
-#define MOVE_COOLTIME_MIN 300    //  MOVE_COOLTIME_MAXに固定+300
+#define MOVE_COOLTIME_MAX 50    //  Randで0~500
+#define MOVE_COOLTIME_MIN 10    //  MOVE_COOLTIME_MAXに固定+300
 
 class cUnitMgr : public cBaseTask{
 
@@ -142,7 +142,7 @@ public:
 		int spawnRoom = m_mapData.size() - 1;
 
 		if (m_roomEnemy[spawnRoom].size() >= m_mapData[spawnRoom].roomSize) return 0;
-		enemy.emplace_back(new cESord(_x, _y, spawnRoom, m_num));
+		enemy.emplace_back(new cEArcher(_x, _y, spawnRoom, m_num));
 		m_num++;
 
 		return 0;
@@ -153,7 +153,7 @@ public:
 		int spawnRoom = m_mapData.size() - 1;
 
 		if (m_roomEnemy[spawnRoom].size() >= m_mapData[spawnRoom].roomSize) return 0;
-		enemy.emplace_back(new cESord(_x, _y, spawnRoom, m_num));
+		enemy.emplace_back(new cEDefense(_x, _y, spawnRoom, m_num));
 		m_num++;
 
 		return 0;


### PR DESCRIPTION
[update] ランダム出現のエネミーが全部ESordだったのを改善
GameMgrの変更点はマップ番号0の床の座標を送ってます。

﻿↑↑実装の概要(必ず記入)↑↑
●フリー記入覧
　
 ※下記の物はあれば記入すること
●レビューして欲しいところ
●ここはこうしたけどこの点で問題はないだろうか
●不安に思っていること
●保留してること
●スケジュール(マージすべき日、リリースすべき日の指定があれば)
●関係するプルリクエスト